### PR TITLE
fix: using try catch in the printer helper

### DIFF
--- a/lib/Helper/printer_helper.dart
+++ b/lib/Helper/printer_helper.dart
@@ -58,8 +58,12 @@ class PrinterHelper {
   }
 
   static String getItemIdFromUrl(String url) {
-    var uri = Uri.dataFromString(url);
-    var itemId = uri.pathSegments[3];
-    return itemId;
+    try {
+      var uri = Uri.dataFromString(url);
+      var itemId = uri.pathSegments[3];
+      return itemId;
+    } catch (e) {
+      return '';
+    }
   }
 }


### PR DESCRIPTION
fix the printer helper by using try catch to prevent unsafe code being thrown